### PR TITLE
Update OAuthController.cs

### DIFF
--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -120,7 +120,7 @@ namespace Our.Umbraco.AuthU.Web.Controllers
             var claims = Context.Services.UserService.GetUserClaims(username);
 
             var identity = new ClaimsIdentity("OAuth");
-            identity.AddClaim(new Claim(ClaimTypes.Name, Context.Realm));
+            identity.AddClaim(new Claim(ClaimTypes.Name, username));
             identity.AddClaim(new Claim(OAuth.ClaimTypes.Realm, Context.Realm));
             identity.AddClaims(claims);
 


### PR DESCRIPTION
I think this is a bug.
It takes the realm as the Name, then it always looks for a user named 'default' in the Umbraco members.