### PR TITLE
Avoid duplicate Access-Control-Allow-Origin headers

### DIFF
--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -78,24 +78,26 @@ namespace Our.Umbraco.AuthU.Web.Controllers
             }
         }
 	
-	protected void SetOriginHeader()
-	{
-		string allowedOrigin = Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin;
-
-		if (HttpContext.Current.Response.Headers.AllKeys.Contains("Access-Control-Allow-Origin"))
+		protected void SetOriginHeader()
 		{
-			var accessControlHeader = HttpContext.Current.Response.Headers.GetValues("Access-Control-Allow-Origin").FirstOrDefault();
+			string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
+			string allowedOrigin = Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin;
 
-			if (!accessControlHeader.Equals(allowedOrigin, StringComparison.OrdinalIgnoreCase))
+			if (HttpContext.Current.Response.Headers.AllKeys.Contains(AccessControlAllowOriginHeaderKey))
 			{
-				throw new Exception($"There is currently a header set with the key Access-Control-Allow-Origin, but the value: {accessControlHeader} differs from the OAuth configured value: {allowedOrigin}");
+				var accessControlHeader = HttpContext.Current.Response.Headers.GetValues(AccessControlAllowOriginHeaderKey).FirstOrDefault();
+
+				if (!accessControlHeader.Equals(allowedOrigin, StringComparison.OrdinalIgnoreCase))
+				{
+					string errorMessage = $"There is currently a header set with the key {AccessControlAllowOriginHeaderKey}, but the value: {accessControlHeader} differs from the OAuth configured value: {allowedOrigin}";
+					throw new OAuthResponseException(HttpStatusCode.InternalServerError, new { invalid_allowed_origin = errorMessage });
+				}
+			}
+			else
+			{
+				HttpContext.Current.Response.Headers.Add(AccessControlAllowOriginHeaderKey, allowedOrigin);
 			}
 		}
-		else
-		{
-			HttpContext.Current.Response.Headers.Add("Access-Control-Allow-Origin", Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin);
-		}
-	}
 
         protected object ProcessPasswordTokenRequest(OAuthTokenRequest request)
         {

--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -36,7 +36,7 @@ namespace Our.Umbraco.AuthU.Web.Controllers
 
             ProcessClient(request);
 
-	    SetOriginHeader();
+	    	SetAllowedOriginHeader();
             
             switch (request.grant_type)
             {
@@ -78,7 +78,7 @@ namespace Our.Umbraco.AuthU.Web.Controllers
             }
         }
 	
-		protected void SetOriginHeader()
+		protected void SetAllowedOriginHeader()
 		{
 			string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
 			string allowedOrigin = Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin;

--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -36,10 +36,8 @@ namespace Our.Umbraco.AuthU.Web.Controllers
 
             ProcessClient(request);
 
-            if (!HttpContext.Current.Response.Headers.AllKeys.Contains("Access-Control-Allow-Origin"))
-			{
-				HttpContext.Current.Response.Headers.Add("Access-Control-Allow-Origin", Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin);
-			}
+	    SetOriginHeader();
+            
             switch (request.grant_type)
             {
                 case "password":
@@ -79,6 +77,25 @@ namespace Our.Umbraco.AuthU.Web.Controllers
                 Client = client;
             }
         }
+	
+	protected void SetOriginHeader()
+	{
+		string allowedOrigin = Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin;
+
+		if (HttpContext.Current.Response.Headers.AllKeys.Contains("Access-Control-Allow-Origin"))
+		{
+			var accessControlHeader = HttpContext.Current.Response.Headers.GetValues("Access-Control-Allow-Origin").FirstOrDefault();
+
+			if (!accessControlHeader.Equals(allowedOrigin, StringComparison.OrdinalIgnoreCase))
+			{
+				throw new Exception($"There is currently a header set with the key Access-Control-Allow-Origin, but the value: {accessControlHeader} differs from the OAuth configured value: {allowedOrigin}");
+			}
+		}
+		else
+		{
+			HttpContext.Current.Response.Headers.Add("Access-Control-Allow-Origin", Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin);
+		}
+	}
 
         protected object ProcessPasswordTokenRequest(OAuthTokenRequest request)
         {

--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -35,8 +35,10 @@ namespace Our.Umbraco.AuthU.Web.Controllers
 
             ProcessClient(request);
 
-            HttpContext.Current.Response.Headers.Add("Access-Control-Allow-Origin", Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin);
-
+            if (!HttpContext.Current.Response.Headers.AllKeys.Contains("Access-Control-Allow-Origin"))
+			{
+				HttpContext.Current.Response.Headers.Add("Access-Control-Allow-Origin", Client != null ? Client.AllowedOrigin : Context.Options.AllowedOrigin);
+			}
             switch (request.grant_type)
             {
                 case "password":

--- a/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
+++ b/src/Our.Umbraco.AuthU/Web/Controllers/OAuthController.cs
@@ -5,6 +5,7 @@ using System.Web;
 using System.Web.Http;
 using Our.Umbraco.AuthU.Extensions;
 using Our.Umbraco.AuthU.Models;
+using System.Linq;
 
 namespace Our.Umbraco.AuthU.Web.Controllers
 {


### PR DESCRIPTION
I had the same issue as Steffeng87 (issue #4). This new code checks first if there is a header with the key "Access-Control-Allow-Origin" and only if it does not exist, does it add the header. This avoids the problem of duplicate headers.