### PR TITLE
Add support for logging in on multiple devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ With an endpoint configured, initial authentication can be performed by sending 
 * __password__ = The users password
 * __client_id__ = A valid client id (Only required if a client store is configured)
 * __client_secret__ = A valid client secret (Only required if a client store is configured, and the client is "secure")
+* __device_id__ = An optional device id to associate the token with, allowing login from multiple devices
 
 Example (with client store and refresh token stores configured):
 
@@ -97,7 +98,7 @@ Example (with client store and refresh token stores configured):
     Request Headers:
       Content-Type: application/x-www-form-urlencoded
     Request POST Body:
-      grant_type=password&username=joebloggs&password=password1234&client_id=myclient&client_secret=myclientsecret
+      grant_type=password&username=joebloggs&password=password1234&client_id=myclient&client_secret=myclientsecret&device_id=edfb6f01-2342-47f8-a5ee-a520969539d0
     Response:
     {
       "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1laWQiOiIxMDgxIiwidW5pcXVlX25hbWUiOiJtZW1iZXIiLCJyb2xlIjoiTWVtYmVyIiwicmVhbG0iOiJkZWZhdWx0IiwiZXhwIjoxNDg3NDk2NzM3LCJuYmYiOjE0ODc0OTU1Mzd9.9uiIxrPggvH5nyLbH4UKIL52V6l5mpOyJ26J12FkXvI",
@@ -111,6 +112,7 @@ A subsequent refresh token authentication request can be performed by sending a 
 * __refresh_token__ = The refresh token returned from the original authentication request
 * __client_id__ = A valid client id (Only required if a client store is configured)
 * __client_secret__ = A valid client secret (Only required if a client store is configured, and the client is "secure")
+* __device_id__ = An optional device id to associate the token with, allowing login from multiple devices
 
 Example (with client store and refresh token stores configured):
 
@@ -119,7 +121,7 @@ Example (with client store and refresh token stores configured):
     Request Headers:
       Content-Type: application/x-www-form-urlencoded
     Request POST Body:
-      grant_type=refresh_token&refresh_token=b3cc9c66b86340c5b743f2a7cec9d2f1&client_id=myclient&client_secret=myclientsecret
+      grant_type=refresh_token&refresh_token=b3cc9c66b86340c5b743f2a7cec9d2f1&client_id=myclient&client_secret=myclientsecret&device_id=edfb6f01-2342-47f8-a5ee-a520969539d0
     Response:
     {
       "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1laWQiOiIxMDgxIiwidW5pcXVlX25hbWUiOiJtZW1iZXIiLCJyb2xlIjoiTWVtYmVyIiwicmVhbG0iOiJkZWZhdWx0IiwiZXhwIjoxNDg3NDk2NzM3LCJuYmYiOjE0ODc0OTU1Mzd9.9uiIxrPggvH5nyLbH4UKIL52V6l5mpOyJ26J12FkXvI",

--- a/src/Our.Umbraco.AuthU/Data/Migrations/BaseMigration.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/BaseMigration.cs
@@ -1,0 +1,31 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.AuthU.Data.Migrations
+{
+	internal abstract class BaseMigration : MigrationBase
+	{
+		protected Database Database
+		{
+			get
+			{
+				return ApplicationContext.Current.DatabaseContext.Database;
+			}
+		}
+
+		protected DatabaseSchemaHelper SchemaHelper
+		{
+			get
+			{
+				return new DatabaseSchemaHelper(Database, Logger, SqlSyntax);
+			}
+		}
+
+		protected BaseMigration(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+			: base(sqlSyntax, logger)
+		{ }
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/Migrations/MigrationsRunner.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/MigrationsRunner.cs
@@ -1,0 +1,42 @@
+﻿using Semver;
+using System;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+
+namespace Our.Umbraco.AuthU.Data.Migrations
+{
+	internal class MigrationsRunner
+	{
+		public static void RunMigrations(string version, string productName)
+		{
+			var currentVersion = new SemVersion(0, 0, 0);
+
+			var migrations = ApplicationContext.Current.Services.MigrationEntryService.GetAll(productName);
+			var latestMigration = migrations.OrderByDescending(x => x.Version).FirstOrDefault();
+			if (latestMigration != null)
+				currentVersion = latestMigration.Version;
+
+			var targetVersion = SemVersion.Parse(version);
+			if (targetVersion == currentVersion)
+				return;
+
+			var migrationsRunner = new MigrationRunner(
+			  ApplicationContext.Current.Services.MigrationEntryService,
+			  ApplicationContext.Current.ProfilingLogger.Logger,
+			  currentVersion,
+			  targetVersion,
+			  productName);
+
+			try
+			{
+				migrationsRunner.Execute(ApplicationContext.Current.DatabaseContext.Database);
+			}
+			catch (Exception e)
+			{
+				LogHelper.Error<MigrationsRunner>($"Error running {productName} migration", e);
+			}
+		}
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthClientStore/1.0.0/CreateDemoClient.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthClientStore/1.0.0/CreateDemoClient.cs
@@ -1,0 +1,37 @@
+﻿using Our.Umbraco.AuthU.Models;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.AuthU.Data.Migrations.UmbracoDbOAuthClientStore
+{
+	[Migration("1.0.0", 2, "AuthU_UmbracoDbOAuthClientStore")]
+	internal class CreateDemoClient : BaseMigration
+	{
+		public CreateDemoClient(ISqlSyntaxProvider sqlSyntax, ILogger logger) 
+			: base(sqlSyntax, logger)
+		{ }
+
+		public override void Up()
+		{
+			var existing = Database.SingleOrDefault<OAuthClient>($"SELECT * FROM [OAuthClient] WHERE [ClientId] = @0", "DemoClient");
+			if (existing == null)
+			{
+				Database.Save(new OAuthClient
+				{
+					ClientId = "DemoClient",
+					Name = "Demo Client",
+					Secret = "demo",
+					SecurityLevel = SecurityLevel.Insecure,
+					RefreshTokenLifeTime = 14400,
+					AllowedOrigin = "*"
+				});
+			}
+		}
+
+		public override void Down()
+		{
+			Database.Execute("DELETE [OAuthClient] WHERE [ClientId] = @0", "DemoClient");
+		}
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthClientStore/1.0.0/CreateTable.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthClientStore/1.0.0/CreateTable.cs
@@ -1,0 +1,25 @@
+﻿using Our.Umbraco.AuthU.Models;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.AuthU.Data.Migrations.UmbracoDbOAuthClientStore
+{
+	[Migration("1.0.0", 1, Data.UmbracoDbOAuthClientStore.SubProductName)]
+	internal class CreateTable : BaseMigration
+	{
+		public CreateTable(ISqlSyntaxProvider sqlSyntax, ILogger logger) 
+			: base(sqlSyntax, logger)
+		{ }
+
+		public override void Up()
+		{
+			SchemaHelper.CreateTable<OAuthClient>(false);
+		}
+
+		public override void Down()
+		{
+			SchemaHelper.DropTable<OAuthClient>();
+		}
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthRefreshTokenStore/1.0.0/CreateTable.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthRefreshTokenStore/1.0.0/CreateTable.cs
@@ -1,0 +1,25 @@
+﻿using Our.Umbraco.AuthU.Models;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.AuthU.Data.Migrations.UmbracoDbOAuthRefreshTokenStore
+{
+	[Migration("1.0.0", 1, Data.UmbracoDbOAuthRefreshTokenStore.SubProductName)]
+	internal class CreateTable : BaseMigration
+	{
+		public CreateTable(ISqlSyntaxProvider sqlSyntax, ILogger logger) 
+			: base(sqlSyntax, logger)
+		{ }
+
+		public override void Up()
+		{
+			SchemaHelper.CreateTable<OAuthRefreshToken>(false);
+		}
+
+		public override void Down()
+		{
+			SchemaHelper.DropTable<OAuthRefreshToken>();
+		}
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthRefreshTokenStore/1.0.1/AddDeviceIdColumn.cs
+++ b/src/Our.Umbraco.AuthU/Data/Migrations/UmbracoDbOAuthRefreshTokenStore/1.0.1/AddDeviceIdColumn.cs
@@ -1,0 +1,24 @@
+﻿using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.AuthU.Data.Migrations.UmbracoDbOAuthRefreshTokenStore
+{
+	[Migration("1.0.1", 1, Data.UmbracoDbOAuthRefreshTokenStore.SubProductName)]
+	internal class AddDeviceIdColumn : BaseMigration
+	{
+		public AddDeviceIdColumn(ISqlSyntaxProvider sqlSyntax, ILogger logger) 
+			: base(sqlSyntax, logger)
+		{ }
+
+		public override void Up()
+		{
+			Alter.Table("OAuthRefreshToken").AddColumn("DeviceId").AsString().Nullable();
+		}
+
+		public override void Down()
+		{
+			Delete.Column("DeviceId").FromTable("OAuthRefreshToken");
+		}
+	}
+}

--- a/src/Our.Umbraco.AuthU/Data/UmbracoDbOAuthClientStore.cs
+++ b/src/Our.Umbraco.AuthU/Data/UmbracoDbOAuthClientStore.cs
@@ -1,47 +1,27 @@
 ﻿using Umbraco.Core;
-using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Our.Umbraco.AuthU.Interfaces;
 using Our.Umbraco.AuthU.Models;
+using Our.Umbraco.AuthU.Data.Migrations;
 
 namespace Our.Umbraco.AuthU.Data
 {
     public class UmbracoDbOAuthClientStore : IOAuthClientStore
     {
-        protected Database Db => ApplicationContext.Current.DatabaseContext.Database;
+		internal const string CurrentVersion = "1.0.0";
+		internal const string SubProductName = "AuthU_UmbracoDbOAuthClientStore";
+
+		protected Database Db => ApplicationContext.Current.DatabaseContext.Database;
 
         public UmbracoDbOAuthClientStore()
         {
-            this.EnsureTablesExist();
-        }
+			MigrationsRunner.RunMigrations(CurrentVersion, SubProductName);
+		}
 
         public OAuthClient FindClient(string clientId)
         {
-            return this.Db.SingleOrDefault<OAuthClient>("SELECT * FROM [OAuthClient] WHERE [ClientId] = @0",
+            return Db.SingleOrDefault<OAuthClient>("SELECT * FROM [OAuthClient] WHERE [ClientId] = @0",
                 clientId);
-        }
-
-        protected void EnsureTablesExist()
-        {
-            var dbCtx = ApplicationContext.Current.DatabaseContext;
-            var dbSchemaHelper = new DatabaseSchemaHelper(dbCtx.Database, LoggerResolver.Current.Logger, dbCtx.SqlSyntax);
-
-            if (!dbSchemaHelper.TableExist(typeof(OAuthClient).Name))
-            {
-                // Create table
-                dbSchemaHelper.CreateTable(false, typeof(OAuthClient));
-
-                // Seed the table
-                dbCtx.Database.Save(new OAuthClient
-                {
-                    ClientId = "DemoClient",
-                    Name = "Demo Client",
-                    Secret = "demo",
-                    SecurityLevel = SecurityLevel.Insecure,
-                    RefreshTokenLifeTime = 14400,
-                    AllowedOrigin = "*"
-                });
-            }
         }
     }
 }

--- a/src/Our.Umbraco.AuthU/Data/UmbracoDbOAuthRefreshTokenStore.cs
+++ b/src/Our.Umbraco.AuthU/Data/UmbracoDbOAuthRefreshTokenStore.cs
@@ -1,27 +1,31 @@
 ﻿using Umbraco.Core;
-using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence;
 using Our.Umbraco.AuthU.Interfaces;
 using Our.Umbraco.AuthU.Models;
+using Our.Umbraco.AuthU.Data.Migrations;
 
 namespace Our.Umbraco.AuthU.Data
 {
     public class UmbracoDbOAuthRefreshTokenStore : IOAuthRefreshTokenStore
-    {
-        protected Database Db => ApplicationContext.Current.DatabaseContext.Database;
+	{
+		internal const string CurrentVersion = "1.0.1";
+		internal const string SubProductName = "AuthU_UmbracoDbOAuthRefreshTokenStore";
+
+		protected Database Db => ApplicationContext.Current.DatabaseContext.Database;
 
         public UmbracoDbOAuthRefreshTokenStore()
         {
-            EnsureTablesExist();
-        }
+			MigrationsRunner.RunMigrations(CurrentVersion, SubProductName);
+		}
 
         public void AddRefreshToken(OAuthRefreshToken token)
         {
-            Db.Execute("DELETE FROM [OAuthRefreshToken] WHERE [Subject] = @0 AND [UserType] = @1 AND [Realm] = @2 AND [ClientId] = @3",
+            Db.Execute("DELETE FROM [OAuthRefreshToken] WHERE [Subject] = @0 AND [UserType] = @1 AND [Realm] = @2 AND [ClientId] = @3 AND [DeviceId] = @4",
                 token.Subject,
                 token.UserType,
                 token.Realm,
-                token.ClientId);
+                token.ClientId,
+				token.DeviceId);
 
             Db.Save(token);
         }
@@ -36,17 +40,6 @@ namespace Our.Umbraco.AuthU.Data
         {
             return Db.SingleOrDefault<OAuthRefreshToken>("SELECT * FROM [OAuthRefreshToken] WHERE [Key] = @0",
                 refreshTokenId);
-        }
-
-        protected void EnsureTablesExist()
-        {
-            var dbCtx = ApplicationContext.Current.DatabaseContext;
-            var dbSchemaHelper = new DatabaseSchemaHelper(dbCtx.Database, LoggerResolver.Current.Logger, dbCtx.SqlSyntax);
-
-            if (!dbSchemaHelper.TableExist(typeof(OAuthRefreshToken).Name))
-            {
-                dbSchemaHelper.CreateTable(false, typeof(OAuthRefreshToken));
-            }
         }
     }
 }

--- a/src/Our.Umbraco.AuthU/Models/OAuthRefreshToken.cs
+++ b/src/Our.Umbraco.AuthU/Models/OAuthRefreshToken.cs
@@ -25,7 +25,10 @@ namespace Our.Umbraco.AuthU.Models
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public string ClientId { get; set; }
 
-        [NullSetting(NullSetting = NullSettings.NotNull)]
+		[NullSetting(NullSetting = NullSettings.Null)]
+		public string DeviceId { get; set; }
+
+		[NullSetting(NullSetting = NullSettings.NotNull)]
         public DateTime IssuedUtc { get; set; }
 
         [NullSetting(NullSetting = NullSettings.NotNull)]

--- a/src/Our.Umbraco.AuthU/Models/OAuthTokenRequest.cs
+++ b/src/Our.Umbraco.AuthU/Models/OAuthTokenRequest.cs
@@ -12,6 +12,8 @@
 
         public string client_secret { get; set; }
 
-        public string refresh_token { get; set; }
+		public string device_id { get; set; }
+
+		public string refresh_token { get; set; }
     }
 }

--- a/src/Our.Umbraco.AuthU/OAuthConstants.cs
+++ b/src/Our.Umbraco.AuthU/OAuthConstants.cs
@@ -11,6 +11,7 @@
         internal static class ClaimTypes
         {
             internal static readonly string Realm = "realm";
-        }
+			internal static readonly string DeviceId = "deviceid";
+		}
     }
 }

--- a/src/Our.Umbraco.AuthU/Our.Umbraco.AuthU.csproj
+++ b/src/Our.Umbraco.AuthU/Our.Umbraco.AuthU.csproj
@@ -259,6 +259,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data\InMemoryOAuthClientStore.cs" />
+    <Compile Include="Data\Migrations\BaseMigration.cs" />
+    <Compile Include="Data\Migrations\MigrationsRunner.cs" />
+    <Compile Include="Data\Migrations\UmbracoDbOAuthClientStore\1.0.0\CreateDemoClient.cs" />
+    <Compile Include="Data\Migrations\UmbracoDbOAuthClientStore\1.0.0\CreateTable.cs" />
+    <Compile Include="Data\Migrations\UmbracoDbOAuthRefreshTokenStore\1.0.0\CreateTable.cs" />
+    <Compile Include="Data\Migrations\UmbracoDbOAuthRefreshTokenStore\1.0.1\AddDeviceIdColumn.cs" />
     <Compile Include="Data\UmbracoDbOAuthClientStore.cs" />
     <Compile Include="Interfaces\IOAuthOptions.cs" />
     <Compile Include="Interfaces\IOAuthClientStore.cs" />


### PR DESCRIPTION
As per issue #29, if you currently log in on multiple devices and use a refresh token to refresh the oauth token, then the refresh token is removed from the DB and thus one of the devices will be unable to authenticate with the refresh token.

This PR adds support for a device_id param as part of the auth request which ties the auth token and refresh token to a given device_id. This way, each device has it's own unique refresh token and so shouldn't get out of sync. If a device_id is provided then it must ALWAYS be provided to the auth endpoint as if the token in the db doesn't match then auth will not be granted. A device_id can be any string and is provided by the client to identify the unique client instance. It is the clients responsibility to ensure uniqueness.