### PR TITLE
Fix SecurityLevel property

### DIFF
--- a/src/Our.Umbraco.AuthU/Models/OAuthClient.cs
+++ b/src/Our.Umbraco.AuthU/Models/OAuthClient.cs
@@ -19,16 +19,8 @@ namespace Our.Umbraco.AuthU.Models
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public string Name { get; set; }
 
-        [Column("SecurityLevel")]
         [NullSetting(NullSetting = NullSettings.NotNull)]
-        public int __SecurityLevel { get; set; }
-
-        [Ignore]
-        public SecurityLevel SecurityLevel
-        {
-            get { return (SecurityLevel)this.__SecurityLevel; }
-            set { this.__SecurityLevel = (int)value; }
-        }
+        public SecurityLevel SecurityLevel { get; set; }
 
         public bool Active { get; set; }
 


### PR DESCRIPTION
I noticed the client_secret isn't being validated, even when the SecurityLevel in the database is set to `1`.
This fixes the issue.